### PR TITLE
Release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+## 0.1.0 (2024-07-03)
+
+### Added
+
+- Add commitizen config for automated releases
+- Add CI tasks for env to test database and run sync tasks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pages-bot",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pages-bot",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "ISC",
       "dependencies": {
         "airtable": "^0.12.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pages-bot",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "A bot to handle admin tasks related to the Pages platform.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## :robot: This is an automated release PR
Tag 0.0.1 could not be found. 
Possible causes:
- version in configuration is not the current version
- tag_format is missing, check them using 'git tag --list'

? Is this the first tag created? (Y/n)






                                        ? Is this the first tag created? Yes
chore: release 0.1.0
tag to create: 0.1.0
increment detected: MINOR

## 0.1.0 (2024-07-03)

### Added

- Add commitizen config for automated releases
- Add CI tasks for env to test database and run sync tasks
## security considerations
Noted in individual PRs
