### PR TITLE
fix(ci): Production git src config key

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -213,6 +213,7 @@ resources:
       commit_verification_keys: ((cloud-gov-pages-gpg-keys))
       tag_filter: 0.*.*
       fetch_tags: true
+      private_key: ((pages-gpg-operations-github-sshkey.private_key))
 
   - name: pages-release
     type: github-release


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixes production git src config with pages-bots `private_key`

## Security considerations

None